### PR TITLE
Add stable multi-arch crossdev toolchains

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ ARG BINUTILS_VER
 ARG GCC_VER
 ARG KERNEL_VER
 ARG LIBC_VER
-ARG CROSSDEV_TARGET=powerpc-unknown-linux-gnu
+# Available arches: amd64 alpha arm arm64 hppa loong mips m68k ppc riscv s390 sparc x86
+ARG CROSSDEV_TARGETS="aarch64-unknown-linux-gnu arm-unknown-linux-gnueabi powerpc-unknown-linux-gnu i686-unknown-linux-gnu"
 
 # Manually create a crossdev repository
 RUN mkdir -p /var/db/repos/crossdev/{profiles,metadata} \
@@ -31,12 +32,14 @@ RUN mkdir -p /var/db/repos/crossdev/{profiles,metadata} \
 RUN mkdir -p /etc/portage/repos.conf \
     && echo -e '[crossdev]\nlocation = /var/db/repos/crossdev\npriority = 10\nmasters = gentoo\nauto-sync = no' > /etc/portage/repos.conf/crossdev.conf
 
-# Conditional execution based on STABLE
-RUN if [ "${STABLE_BUILD}" = "yes" ]; then \
-        crossdev -S --target ${CROSSDEV_TARGET} --show-fail-log; \
-    else \
-        crossdev --b "~${BINUTILS_VER}" --g "~${GCC_VER}" --k "~${KERNEL_VER}" --l "~${LIBC_VER}" --target ${CROSSDEV_TARGET} --show-fail-log; \
-    fi
+# Conditional execution based on STABLE for each target
+RUN for target in ${CROSSDEV_TARGETS}; do \
+        if [ "${STABLE_BUILD}" = "yes" ]; then \
+            crossdev -S --target ${target} --show-fail-log; \
+        else \
+            crossdev --b "~${BINUTILS_VER}" --g "~${GCC_VER}" --k "~${KERNEL_VER}" --l "~${LIBC_VER}" --target ${target} --show-fail-log; \
+        fi; \
+    done
 
 # Create a non-root user for security purposes
 RUN useradd -m -G users,distcc crossdevuser

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Gentoo PPC32 Cross-Compile Docker Project
+# Gentoo Multi-Arch Cross-Compile Docker Project
 
-This project provides a Docker setup for cross-compiling for Gentoo PPC32 using `distcc` and `crossdev`, running natively on AMD64.
+This project provides a Docker setup for cross-compiling for Gentoo using `distcc` and `crossdev`, running natively on AMD64. It builds stable toolchains for **arm64**, **arm**, **ppc32**, and **x86** targets.
 
 ## Features
 
 - Gentoo Stage3 AMD64 base image.
 - `distcc` and `crossdev` for efficient cross-compiling.
-- Configuration for PPC32 cross-compilation.
+- Stable toolchains for arm64, arm, ppc32, and x86 cross-compilation.
 - Customizable `distccd` and `crossdev` settings.
 
 ## Getting Started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,8 @@ services:
         GCC_VER: "11.4.1"     # Replace with the actual version
         KERNEL_VER: "6.6.13"    # Replace with the actual version
         LIBC_VER: "2.38"     # Replace with the actual version
-        CROSSDEV_TARGET: "powerpc-unknown-linux-gnu" # Replace with tuple
+        CROSSDEV_TARGETS: "aarch64-unknown-linux-gnu arm-unknown-linux-gnueabi powerpc-unknown-linux-gnu i686-unknown-linux-gnu" # Multi-arch targets: arm64 arm ppc32 x86
+        # Available arches: amd64 alpha arm arm64 hppa loong mips m68k ppc riscv s390 sparc x86
     environment:
       DISTCCD_JOBS: 4
       DISTCCD_ALLOW: "192.168.1.0/0" # Replace with your IP or range


### PR DESCRIPTION
## Summary
- build stable crossdev toolchains for arm64, arm, ppc32, and x86
- expose multi-arch targets via docker-compose
- document all available architectures in build configuration

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68964d8b812c8333a4f2a2f41e71b727