### PR TITLE
Use pc vendor for i686 target and nomultilib base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Use Gentoo stage3 AMD64 as the base image
-FROM gentoo/stage3:amd64-openrc
+ARG BASE_IMAGE=gentoo/stage3:amd64-openrc
+FROM ${BASE_IMAGE}
 
 # Update the system and sync portage
 RUN emerge-webrsync
@@ -20,7 +21,7 @@ ARG GCC_VER
 ARG KERNEL_VER
 ARG LIBC_VER
 # Available arches: amd64 alpha arm arm64 hppa loong mips m68k ppc riscv s390 sparc x86
-ARG CROSSDEV_TARGETS="aarch64-unknown-linux-gnu arm-unknown-linux-gnueabi powerpc-unknown-linux-gnu i686-unknown-linux-gnu"
+ARG CROSSDEV_TARGETS="aarch64-unknown-linux-gnu arm-unknown-linux-gnueabi powerpc-unknown-linux-gnu i686-pc-linux-gnu"
 
 # Manually create a crossdev repository
 RUN mkdir -p /var/db/repos/crossdev/{profiles,metadata} \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,13 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
+        BASE_IMAGE: "gentoo/stage3:amd64-nomultilib-openrc" # Use nomultilib profile
         STABLE_BUILD: "yes"  # Use "yes" for stable, "no" for finetuned binutils,gcc,kernel,libc
         BINUTILS_VER: "2.41" # Replace with the actual version if unstable
         GCC_VER: "11.4.1"     # Replace with the actual version
         KERNEL_VER: "6.6.13"    # Replace with the actual version
         LIBC_VER: "2.38"     # Replace with the actual version
-        CROSSDEV_TARGETS: "aarch64-unknown-linux-gnu arm-unknown-linux-gnueabi powerpc-unknown-linux-gnu i686-unknown-linux-gnu" # Multi-arch targets: arm64 arm ppc32 x86
+        CROSSDEV_TARGETS: "aarch64-unknown-linux-gnu arm-unknown-linux-gnueabi powerpc-unknown-linux-gnu i686-pc-linux-gnu" # Multi-arch targets: arm64 arm ppc32 x86
         # Available arches: amd64 alpha arm arm64 hppa loong mips m68k ppc riscv s390 sparc x86
     environment:
       DISTCCD_JOBS: 4


### PR DESCRIPTION
## Summary
- use `i686-pc-linux-gnu` crossdev target instead of `i686-unknown-linux-gnu`
- allow overriding the stage3 base image and set docker-compose to use `amd64-nomultilib` for a no-multilib host

## Testing
- `docker-compose config`
- `docker compose config` *(fails: 'compose' is not a docker command)*
- `docker version` *(fails: cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68986caa4ea883338e995c4eb150109a